### PR TITLE
Fixes a bug in the Deserializer

### DIFF
--- a/SharedCode/ScanSerializer.cs
+++ b/SharedCode/ScanSerializer.cs
@@ -61,7 +61,7 @@ namespace Data.Scans
 
 		public Scan DeserializeScanFromXML(String filePath)
 		{
-			Stream scanStream = new FileStream(filePath, FileMode.Create);
+			Stream scanStream = new FileStream(filePath, FileMode.Open);
 			Scan scan = (Scan)xmls.Deserialize(scanStream);
 			scanStream.Close();
 			return scan;


### PR DESCRIPTION
Previously, the Filemode.Create meant your data file got overwritten when you try to open it.
